### PR TITLE
Improve Quick Settings Tile refresh

### DIFF
--- a/app/src/main/java/io/github/dovecoteescapee/byedpi/services/ByeDpiProxyService.kt
+++ b/app/src/main/java/io/github/dovecoteescapee/byedpi/services/ByeDpiProxyService.kt
@@ -2,9 +2,11 @@ package io.github.dovecoteescapee.byedpi.services
 
 import android.app.Notification
 import android.app.NotificationManager
+import android.content.ComponentName
 import android.content.Intent
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
 import android.os.Build
+import android.service.quicksettings.TileService
 import android.util.Log
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
@@ -221,6 +223,7 @@ class ByeDpiProxyService : LifecycleService() {
         )
         intent.putExtra(SENDER, Sender.Proxy.ordinal)
         sendBroadcast(intent)
+        updateQuickSettingsTile()
     }
 
     private fun createNotification(): Notification =
@@ -244,4 +247,12 @@ class ByeDpiProxyService : LifecycleService() {
         val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.notify(PAUSE_NOTIFICATION_ID, notification)
     }
+
+    private fun updateQuickSettingsTile() {
+        TileService.requestListeningState(
+            this,
+            ComponentName(this, QuickTileService::class.java)
+        )
+    }
+
 }

--- a/app/src/main/java/io/github/dovecoteescapee/byedpi/services/ByeDpiStatus.kt
+++ b/app/src/main/java/io/github/dovecoteescapee/byedpi/services/ByeDpiStatus.kt
@@ -2,10 +2,19 @@ package io.github.dovecoteescapee.byedpi.services
 
 import io.github.dovecoteescapee.byedpi.data.AppStatus
 import io.github.dovecoteescapee.byedpi.data.Mode
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
+@Volatile
 var appStatus = AppStatus.Halted to Mode.VPN
     private set
 
+private val appStatusState = MutableStateFlow(appStatus)
+val appStatusFlow: StateFlow<Pair<AppStatus, Mode>> = appStatusState.asStateFlow()
+
 fun setStatus(status: AppStatus, mode: Mode) {
-    appStatus = status to mode
+    val updated = status to mode
+    appStatus = updated
+    appStatusState.value = updated
 }

--- a/app/src/main/java/io/github/dovecoteescapee/byedpi/services/ByeDpiVpnService.kt
+++ b/app/src/main/java/io/github/dovecoteescapee/byedpi/services/ByeDpiVpnService.kt
@@ -3,10 +3,12 @@ package io.github.dovecoteescapee.byedpi.services
 import android.app.Notification
 import android.app.NotificationManager
 import android.app.PendingIntent
+import android.content.ComponentName
 import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.ParcelFileDescriptor
+import android.service.quicksettings.TileService
 import android.util.Log
 import androidx.lifecycle.lifecycleScope
 import io.github.dovecoteescapee.byedpi.R
@@ -316,6 +318,7 @@ class ByeDpiVpnService : LifecycleVpnService() {
         )
         intent.putExtra(SENDER, Sender.VPN.ordinal)
         sendBroadcast(intent)
+        updateQuickSettingsTile()
     }
 
     private fun createNotification(): Notification =
@@ -338,6 +341,13 @@ class ByeDpiVpnService : LifecycleVpnService() {
 
         val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.notify(PAUSE_NOTIFICATION_ID, notification)
+    }
+
+    private fun updateQuickSettingsTile() {
+        TileService.requestListeningState(
+            this,
+            ComponentName(this, QuickTileService::class.java)
+        )
     }
 
     private fun createBuilder(dns: String, ipv6: Boolean): Builder {


### PR DESCRIPTION
currently the quick settings tile only updates when when it starts listening or if it's clicked, so if the appStatus is updated while the QS Tile is active (i.e. by starting a different VPN service or by stopping ByeByeDPI from a notification) -- the QS Tile stays stale.

This PR:
- adds TileService.requestListeningState calls to Proxy and VPN Services on change
- refactors the QuickSettingsTile to use a State Flow instead of direct property access, so `.collect` can be used to react if the state changes while listening