### PR TITLE
Material You переключатели

### DIFF
--- a/app/src/main/java/io/github/dovecoteescapee/byedpi/fragments/MainSettingsFragment.kt
+++ b/app/src/main/java/io/github/dovecoteescapee/byedpi/fragments/MainSettingsFragment.kt
@@ -161,10 +161,10 @@ class MainSettingsFragment : PreferenceFragmentCompat() {
     }
 
     private fun updatePreferences() {
-        val cmdEnable = findPreferenceNotNull<SwitchPreference>("byedpi_enable_cmd_settings").isChecked
+        val cmdEnable = findPreferenceNotNull<SwitchPreferenceCompat>("byedpi_enable_cmd_settings").isChecked
         val mode = findPreferenceNotNull<ListPreference>("byedpi_mode").value.let { Mode.fromString(it) }
         val dns = findPreferenceNotNull<EditTextPreference>("dns_ip")
-        val ipv6 = findPreferenceNotNull<SwitchPreference>("ipv6_enable")
+        val ipv6 = findPreferenceNotNull<SwitchPreferenceCompat>("ipv6_enable")
         val proxy = findPreferenceNotNull<PreferenceCategory>("byedpi_proxy_category")
 
         val applistType = findPreferenceNotNull<ListPreference>("applist_type")

--- a/app/src/main/java/io/github/dovecoteescapee/byedpi/fragments/ProxyTestSettingsFragment.kt
+++ b/app/src/main/java/io/github/dovecoteescapee/byedpi/fragments/ProxyTestSettingsFragment.kt
@@ -52,7 +52,7 @@ class ProxyTestSettingsFragment : PreferenceFragmentCompat() {
     }
 
     private fun updatePreferences() {
-        val switchUserCommands = findPreferenceNotNull<SwitchPreference>("byedpi_proxytest_usercommands")
+        val switchUserCommands = findPreferenceNotNull<SwitchPreferenceCompat>("byedpi_proxytest_usercommands")
         val textUserDomains = findPreferenceNotNull<EditTextPreference>("byedpi_proxytest_domains")
         val textUserCommands = findPreferenceNotNull<EditTextPreference>("byedpi_proxytest_commands")
         val domainLists = findPreferenceNotNull<MultiSelectListPreference>("byedpi_proxytest_domain_lists")

--- a/app/src/main/res/layout/preference_material_switch.xml
+++ b/app/src/main/res/layout/preference_material_switch.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.materialswitch.MaterialSwitch xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/switchWidget"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:background="@null"
+    android:clickable="false"
+    android:focusable="false" />

--- a/app/src/main/res/values-night-v31/themes.xml
+++ b/app/src/main/res/values-night-v31/themes.xml
@@ -18,6 +18,7 @@
         <item name="android:textAppearanceListItem">@style/TextPrimary</item>
         <item name="android:textAppearanceListItemSecondary">@style/TextSummary</item>
         <item name="android:textAppearanceListItemSmall">@style/TextSummary</item>
+        <item name="preferenceTheme">@style/ThemeOverlay.App.Preference</item>
     </style>
 
     <style name="Theme.ByeDPI.History.PaddingLeft" parent="Theme.ByeDPI">

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -9,6 +9,7 @@
         <item name="colorOnSecondary">#FFFFFF</item>
 
         <item name="android:statusBarColor">#000000</item>
+        <item name="preferenceTheme">@style/ThemeOverlay.App.Preference</item>
     </style>
 
     <style name="Theme.ByeDPI.History.PaddingLeft" parent="Theme.ByeDPI">

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -18,6 +18,7 @@
         <item name="android:textAppearanceListItem">@style/TextPrimary</item>
         <item name="android:textAppearanceListItemSecondary">@style/TextSummary</item>
         <item name="android:textAppearanceListItemSmall">@style/TextSummary</item>
+        <item name="preferenceTheme">@style/ThemeOverlay.App.Preference</item>
     </style>
 
     <style name="Theme.ByeDPI.History.PaddingLeft" parent="Theme.ByeDPI">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -9,6 +9,7 @@
         <item name="colorOnSecondary">#FFFFFF</item>
 
         <item name="android:statusBarColor">#3C52A3</item>
+        <item name="preferenceTheme">@style/ThemeOverlay.App.Preference</item>
     </style>
 
     <style name="Theme.ByeDPI.History.PaddingLeft" parent="Theme.ByeDPI">
@@ -17,5 +18,13 @@
 
     <style name="Theme.ByeDPI.History.NoPaddingLeft" parent="Theme.ByeDPI">
         <item name="history_pref_icon_space">16dp</item>
+    </style>
+
+    <style name="ThemeOverlay.App.Preference" parent="PreferenceThemeOverlay">
+        <item name="switchPreferenceCompatStyle">@style/App.Preference.SwitchPreference</item>
+    </style>
+
+    <style name="App.Preference.SwitchPreference" parent="Preference.SwitchPreference.Material">
+        <item name="android:widgetLayout">@layout/preference_material_switch</item>
     </style>
 </resources>

--- a/app/src/main/res/xml/main_settings.xml
+++ b/app/src/main/res/xml/main_settings.xml
@@ -37,7 +37,7 @@
             android:defaultValue="8.8.8.8"
             app:useSimpleSummaryProvider="true" />
 
-        <SwitchPreference
+        <androidx.preference.SwitchPreferenceCompat
             android:key="ipv6_enable"
             android:title="@string/ipv6_setting"
             android:defaultValue="false" />
@@ -60,12 +60,12 @@
     <androidx.preference.PreferenceCategory
         android:title="@string/automation">
 
-        <SwitchPreference
+        <androidx.preference.SwitchPreferenceCompat
             android:key="autostart"
             android:title="@string/autostart_settings"
             android:defaultValue="false" />
 
-        <SwitchPreference
+        <androidx.preference.SwitchPreferenceCompat
             android:key="auto_connect"
             android:title="@string/autoconnect_settings"
             android:defaultValue="false" />
@@ -75,7 +75,7 @@
     <androidx.preference.PreferenceCategory
         android:title="@string/byedpi_category">
 
-        <SwitchPreference
+        <androidx.preference.SwitchPreferenceCompat
             android:key="byedpi_enable_cmd_settings"
             android:title="@string/use_command_line_settings"
             android:defaultValue="false" />
@@ -116,7 +116,7 @@
             android:defaultValue="1080"
             app:useSimpleSummaryProvider="true" />
 
-        <SwitchPreference
+        <androidx.preference.SwitchPreferenceCompat
             android:key="byedpi_http_connect"
             android:title="@string/byedpi_http_connect_setting"
             android:defaultValue="false"

--- a/app/src/main/res/xml/proxy_test_settings.xml
+++ b/app/src/main/res/xml/proxy_test_settings.xml
@@ -30,11 +30,11 @@
         android:defaultValue="google.com"
         app:useSimpleSummaryProvider="true" />
 
-    <SwitchPreference
+    <androidx.preference.SwitchPreferenceCompat
         android:key="byedpi_proxytest_fulllog"
         android:title="@string/test_settings_fulllog" />
 
-    <SwitchPreference
+    <androidx.preference.SwitchPreferenceCompat
         android:key="byedpi_proxytest_logclickable"
         android:title="@string/test_settings_logclickable" />
 
@@ -53,7 +53,7 @@
         android:inputType="textMultiLine"
         app:useSimpleSummaryProvider="true" />
 
-    <SwitchPreference
+    <androidx.preference.SwitchPreferenceCompat
         android:key="byedpi_proxytest_usercommands"
         android:title="@string/test_settings_usercommands" />
 


### PR DESCRIPTION
Было:
<img width="385" height="671" alt="image" src="https://github.com/user-attachments/assets/699d4873-3d01-4457-9bf1-a25592b4a3c2" />

Стало:
<img width="381" height="669" alt="image" src="https://github.com/user-attachments/assets/31e08379-8d11-41a0-91d4-944b075f7a39" />

Тестировалось на Android 15. При обновлении приложения настройки не сбросились.