### PR TITLE
fix crashing app while stopping service after reboot

### DIFF
--- a/app/src/main/java/io/github/romanvht/byedpi/services/ByeDpiProxyService.kt
+++ b/app/src/main/java/io/github/romanvht/byedpi/services/ByeDpiProxyService.kt
@@ -2,6 +2,7 @@ package io.github.romanvht.byedpi.services
 
 import android.app.Notification
 import android.app.NotificationManager
+import android.app.Service
 import android.content.Intent
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
 import android.os.Build
@@ -135,7 +136,11 @@ class ByeDpiProxyService : LifecycleService() {
             updateStatus(ServiceStatus.Disconnected)
         }
 
-        stopSelf()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            stopForeground(Service.STOP_FOREGROUND_REMOVE)
+        } else {
+            stopSelf()
+        }
     }
 
     private fun startProxy() {
@@ -160,7 +165,11 @@ class ByeDpiProxyService : LifecycleService() {
                 updateStatus(ServiceStatus.Disconnected)
             }
 
-            stopSelf()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                stopForeground(Service.STOP_FOREGROUND_REMOVE)
+            } else {
+                stopSelf()
+            }
         }
 
         Log.i(TAG, "Proxy started")

--- a/app/src/main/java/io/github/romanvht/byedpi/services/ByeDpiVpnService.kt
+++ b/app/src/main/java/io/github/romanvht/byedpi/services/ByeDpiVpnService.kt
@@ -3,6 +3,7 @@ package io.github.romanvht.byedpi.services
 import android.app.Notification
 import android.app.NotificationManager
 import android.app.PendingIntent
+import android.app.Service
 import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.Build
@@ -158,7 +159,11 @@ class ByeDpiVpnService : LifecycleVpnService() {
             updateStatus(ServiceStatus.Disconnected)
         }
 
-        stopSelf()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            stopForeground(Service.STOP_FOREGROUND_REMOVE)
+        } else {
+            stopSelf()
+        }
     }
 
     private fun startProxy() {
@@ -183,7 +188,11 @@ class ByeDpiVpnService : LifecycleVpnService() {
             }
 
             stopTun2Socks()
-            stopSelf()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                stopForeground(Service.STOP_FOREGROUND_REMOVE)
+            } else {
+                stopSelf()
+            }
         }
 
         Log.i(TAG, "Proxy started")


### PR DESCRIPTION
Приложение падает на ATV 12/14, если после перезагрузки устройства попытаться остановить сервис.
Как я понял, необходимо использовать stopForeground вместо stopSelf, так работает корректно.

logcat:
`--------- beginning of crash
02-16 23:20:21.910  3563  3563 E AndroidRuntime: FATAL EXCEPTION: main
02-16 23:20:21.910  3563  3563 E AndroidRuntime: Process: io.github.romanvht.byedpi, PID: 3563
02-16 23:20:21.910  3563  3563 E AndroidRuntime: android.app.ForegroundServiceDidNotStartInTimeException: Context.startForegroundService() did not then call Service.startForeground(): ServiceRecord{27e5a77 u0 io.github.romanvht.byedpi/io.github.romanvht.byedpi.services.ByeDpiVpnService}
02-16 23:20:21.910  3563  3563 E AndroidRuntime: 	at android.app.ActivityThread.throwRemoteServiceException(ActivityThread.java:1932)
02-16 23:20:21.910  3563  3563 E AndroidRuntime: 	at android.app.ActivityThread.access$2700(ActivityThread.java:256)
02-16 23:20:21.910  3563  3563 E AndroidRuntime: 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2165)
02-16 23:20:21.910  3563  3563 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:106)
02-16 23:20:21.910  3563  3563 E AndroidRuntime: 	at android.os.Looper.loopOnce(Looper.java:228)
02-16 23:20:21.910  3563  3563 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:321)
02-16 23:20:21.910  3563  3563 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:7910)
02-16 23:20:21.910  3563  3563 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
02-16 23:20:21.910  3563  3563 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
02-16 23:20:21.910  3563  3563 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1101)
02-16 23:20:21.921   672   772 W ActivityTaskManager:   Force finishing activity io.github.romanvht.byedpi/io.github.romanvht.byedpi.activities.MainActivity
02-16 23:20:21.922   672   772 V WindowManager: Finishing activity r=ActivityRecord{b0f4d8f u0 io.github.romanvht.byedpi/io.github.romanvht.byedpi.activities.MainActivity t10091}, result=0, data=null, reason=force-crash
02-16 23:20:21.923   672   772 V WindowManager: Sending position change to ActivityRecord{b0f4d8f u0 io.github.romanvht.byedpi/io.github.romanvht.byedpi.activities.MainActivity t10091 f}}, onTop: false
02-16 23:20:21.923   672   772 V WindowManager: Waiting for top state to be released by ActivityRecord{b0f4d8f u0 io.github.romanvht.byedpi/`