### PR TITLE
Add Turkey blocked domains list and update Turkish translations

### DIFF
--- a/README-tr.md
+++ b/README-tr.md
@@ -40,8 +40,7 @@ Bu uygulama, [ByeDPIAndroid](https://github.com/dovecoteescapee/ByeDPIAndroid) u
 * Topluluktan kapsamlı talimatlar [ByeByeDPI-Manual](https://byebyedpi.xyz)
 
 ### Türkiye İle İlgili
-* Uygulama Türkiyede uygulanan DPI'ı aşmak için şuanlık yeterlidir. İlk başta çalıştırdığınızda uygulama DPI'ı aşamayabilir. UI editöründen rastgele taktikler deneyebilirsiniz veya şuan Deneysel özellik olan proxy modundan bazı argümanlar alıp onları Komut satırı editöründe deneyebilirsiniz.
-* Türkiye ile alakalı destek için Discord: [nyaex](https://github.com/nyaexx)
+* Uygulama Türkiyede uygulanan DPI'ı aşmak için şuanlık yeterlidir. İlk başta çalıştırdığınızda uygulama DPI'ı aşamayabilir. Proxy Testi kısmından testi başlatıp en iyi sonuçları veren komutu kullanabilirsiniz. Sıra sıra Türkiyede bazı alan adlarına geçici kısıtlamalar uygulandığı için test ettiğiniz **Alan Adı Listeleri**'ini değiştirmeniz gerekebilir.
 
 
 ### ByeByeDPI'yi AdGuard ile nasıl kullanırım?

--- a/app/src/main/assets/proxytest_türkiye.sites
+++ b/app/src/main/assets/proxytest_türkiye.sites
@@ -1,0 +1,5 @@
+roblox.com
+wattpad.com
+pastebin.com
+4shared.com
+wikileaks.org

--- a/app/src/main/java/io/github/romanvht/byedpi/fragments/ProxyTestSettingsFragment.kt
+++ b/app/src/main/java/io/github/romanvht/byedpi/fragments/ProxyTestSettingsFragment.kt
@@ -33,6 +33,7 @@ class ProxyTestSettingsFragment : PreferenceFragmentCompat() {
 
     override fun onResume() {
         super.onResume()
+        updatePreferences()
         sharedPreferences?.registerOnSharedPreferenceChangeListener(preferenceListener)
     }
 

--- a/app/src/main/java/io/github/romanvht/byedpi/utility/DomainListUtils.kt
+++ b/app/src/main/java/io/github/romanvht/byedpi/utility/DomainListUtils.kt
@@ -11,6 +11,11 @@ object DomainListUtils {
 
     private val gson = Gson()
 
+    fun getDefaultActiveIds(lang: String): Set<String> = when (lang) {
+        "tr" -> setOf("türkiye", "discord")
+        else -> setOf("youtube", "googlevideo")
+    }
+
     fun syncLists(context: Context) {
         val currentLists = getAllLists(context).toMutableList()
 
@@ -46,7 +51,7 @@ object DomainListUtils {
                             id = id,
                             name = id.replaceFirstChar { it.uppercase() },
                             domains = domains,
-                            isActive = id in SettingsUtils.getDefaultActiveIds(SettingsUtils.getCurrentLanguage(context)),
+                            isActive = id in getDefaultActiveIds(SettingsUtils.getCurrentLanguage(context)),
                             isBuiltIn = true
                         )
                     )

--- a/app/src/main/java/io/github/romanvht/byedpi/utility/DomainListUtils.kt
+++ b/app/src/main/java/io/github/romanvht/byedpi/utility/DomainListUtils.kt
@@ -1,6 +1,7 @@
 package io.github.romanvht.byedpi.utility
 
 import android.content.Context
+import android.os.Build
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import io.github.romanvht.byedpi.data.DomainList
@@ -11,6 +12,19 @@ object DomainListUtils {
 
     private val gson = Gson()
 
+    private fun getCurrentLanguage(context: Context): String {
+        val appLocales = androidx.appcompat.app.AppCompatDelegate.getApplicationLocales()
+        return if (!appLocales.isEmpty) {
+            appLocales[0]?.language ?: "en"
+        } else {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                context.resources.configuration.locales[0].language
+            } else {
+                @Suppress("DEPRECATION")
+                context.resources.configuration.locale.language
+            }
+        }
+    }
     fun syncLists(context: Context) {
         val currentLists = getAllLists(context).toMutableList()
 
@@ -23,6 +37,13 @@ object DomainListUtils {
         } ?: emptyList()
 
         val newBuiltInIds = mutableSetOf<String>()
+
+        val isTurkish = getCurrentLanguage(context) == "tr"
+        val defaultActiveIds = if (isTurkish) {
+            setOf("türkiye", "discord")
+        } else {
+            setOf("youtube", "googlevideo")
+        }
 
         for (assetFile in assetFiles) {
             val id = assetFile
@@ -46,7 +67,7 @@ object DomainListUtils {
                             id = id,
                             name = id.replaceFirstChar { it.uppercase() },
                             domains = domains,
-                            isActive = id in setOf("youtube", "googlevideo"),
+                            isActive = id in defaultActiveIds,
                             isBuiltIn = true
                         )
                     )
@@ -205,7 +226,6 @@ object DomainListUtils {
         if (file.exists()) {
             file.delete()
         }
-
         syncLists(context)
     }
 }

--- a/app/src/main/java/io/github/romanvht/byedpi/utility/DomainListUtils.kt
+++ b/app/src/main/java/io/github/romanvht/byedpi/utility/DomainListUtils.kt
@@ -1,7 +1,6 @@
 package io.github.romanvht.byedpi.utility
 
 import android.content.Context
-import android.os.Build
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import io.github.romanvht.byedpi.data.DomainList
@@ -12,19 +11,6 @@ object DomainListUtils {
 
     private val gson = Gson()
 
-    private fun getCurrentLanguage(context: Context): String {
-        val appLocales = androidx.appcompat.app.AppCompatDelegate.getApplicationLocales()
-        return if (!appLocales.isEmpty) {
-            appLocales[0]?.language ?: "en"
-        } else {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                context.resources.configuration.locales[0].language
-            } else {
-                @Suppress("DEPRECATION")
-                context.resources.configuration.locale.language
-            }
-        }
-    }
     fun syncLists(context: Context) {
         val currentLists = getAllLists(context).toMutableList()
 
@@ -37,13 +23,6 @@ object DomainListUtils {
         } ?: emptyList()
 
         val newBuiltInIds = mutableSetOf<String>()
-
-        val isTurkish = getCurrentLanguage(context) == "tr"
-        val defaultActiveIds = if (isTurkish) {
-            setOf("türkiye", "discord")
-        } else {
-            setOf("youtube", "googlevideo")
-        }
 
         for (assetFile in assetFiles) {
             val id = assetFile
@@ -67,7 +46,7 @@ object DomainListUtils {
                             id = id,
                             name = id.replaceFirstChar { it.uppercase() },
                             domains = domains,
-                            isActive = id in defaultActiveIds,
+                            isActive = id in setOf("youtube", "googlevideo"),
                             isBuiltIn = true
                         )
                     )
@@ -226,6 +205,7 @@ object DomainListUtils {
         if (file.exists()) {
             file.delete()
         }
+
         syncLists(context)
     }
 }

--- a/app/src/main/java/io/github/romanvht/byedpi/utility/DomainListUtils.kt
+++ b/app/src/main/java/io/github/romanvht/byedpi/utility/DomainListUtils.kt
@@ -46,7 +46,7 @@ object DomainListUtils {
                             id = id,
                             name = id.replaceFirstChar { it.uppercase() },
                             domains = domains,
-                            isActive = id in setOf("youtube", "googlevideo"),
+                            isActive = id in SettingsUtils.getDefaultActiveIds(SettingsUtils.getCurrentLanguage(context)),
                             isBuiltIn = true
                         )
                     )

--- a/app/src/main/java/io/github/romanvht/byedpi/utility/SettingsUtils.kt
+++ b/app/src/main/java/io/github/romanvht/byedpi/utility/SettingsUtils.kt
@@ -17,11 +17,6 @@ import io.github.romanvht.byedpi.data.AppSettings
 object SettingsUtils {
     private const val TAG = "SettingsUtils"
 
-    fun getDefaultActiveIds(lang: String): Set<String> = when (lang) {
-        "tr" -> setOf("türkiye", "discord")
-        else -> setOf("youtube", "googlevideo")
-    }
-
     fun getCurrentLanguage(context: Context): String {
         val lang = context.getPreferences().getStringNotNull("language", "system")
         if (lang != "system") return lang

--- a/app/src/main/java/io/github/romanvht/byedpi/utility/SettingsUtils.kt
+++ b/app/src/main/java/io/github/romanvht/byedpi/utility/SettingsUtils.kt
@@ -22,8 +22,14 @@ object SettingsUtils {
         else -> setOf("youtube", "googlevideo")
     }
 
-    fun getCurrentLanguage(context: Context): String =
-        context.getPreferences().getStringNotNull("language", "system")
+    fun getCurrentLanguage(context: Context): String {
+        val lang = context.getPreferences().getStringNotNull("language", "system")
+        if (lang != "system") return lang
+        return AppCompatDelegate.getApplicationLocales()
+            .takeIf { !it.isEmpty }
+            ?.get(0)?.language
+            ?: java.util.Locale.getDefault().language
+    }
 
     fun setLang(lang: String) {
         val appLocale = localeByName(lang) ?: LocaleListCompat.getEmptyLocaleList()

--- a/app/src/main/java/io/github/romanvht/byedpi/utility/SettingsUtils.kt
+++ b/app/src/main/java/io/github/romanvht/byedpi/utility/SettingsUtils.kt
@@ -22,6 +22,9 @@ object SettingsUtils {
         else -> setOf("youtube", "googlevideo")
     }
 
+    fun getCurrentLanguage(context: Context): String =
+        context.getPreferences().getStringNotNull("language", "system")
+
     fun setLang(lang: String) {
         val appLocale = localeByName(lang) ?: LocaleListCompat.getEmptyLocaleList()
 

--- a/app/src/main/java/io/github/romanvht/byedpi/utility/SettingsUtils.kt
+++ b/app/src/main/java/io/github/romanvht/byedpi/utility/SettingsUtils.kt
@@ -17,6 +17,11 @@ import io.github.romanvht.byedpi.data.AppSettings
 object SettingsUtils {
     private const val TAG = "SettingsUtils"
 
+    fun getDefaultActiveIds(lang: String): Set<String> = when (lang) {
+        "tr" -> setOf("türkiye", "discord")
+        else -> setOf("youtube", "googlevideo")
+    }
+
     fun setLang(lang: String) {
         val appLocale = localeByName(lang) ?: LocaleListCompat.getEmptyLocaleList()
 

--- a/app/src/main/res/values-kk/arrays.xml
+++ b/app/src/main/res/values-kk/arrays.xml
@@ -4,7 +4,7 @@
         <item name="system">Автоматты</item>
         <item name="ru">Орыс</item>
         <item name="en">Ағылшын</item>
-        <item name="tr">Түрік</item>
+        <item name="tr">Türkçe</item>
         <item name="kk">Қазақша</item>
         <item name="vi">Tiếng Việt</item>
     </array>

--- a/app/src/main/res/values-tr/arrays.xml
+++ b/app/src/main/res/values-tr/arrays.xml
@@ -17,13 +17,13 @@
 
     <array name="byedpi_hosts_modes">
         <item name="disable">Kapalı</item>
-        <item name="blacklist">Karaliste</item>
-        <item name="whitelist">Beyazliste</item>
+        <item name="blacklist">Kara liste</item>
+        <item name="whitelist">Beyaz liste</item>
     </array>
 
     <array name="applist_types">
         <item name="disable">Kapalı</item>
-        <item name="blacklist">Karaliste</item>
-        <item name="whitelist">Beyazliste</item>
+        <item name="blacklist">Kara liste</item>
+        <item name="whitelist">Beyaz liste</item>
     </array>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -186,5 +186,4 @@
     <string name="donate_message">Uygulama işinize yaradıysa, bana bir fincan kahve ısmarlayabilirsiniz ☕️\nDestek ve katılımınız için teşekkürler ❤️</string>
     <string name="donate_cloudtips">CloudTips (yalnızca Rusya kartları)</string>
     <string name="donate_telegram_bot">Telegram Bot (kartlar, cüzdanlar, kripto)</string>
-    <string name="builtin_list_turkey_blocked">Türkiye Yasaklı Domainler</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -33,7 +33,7 @@
     <string name="mode_setting">Mod</string>
     <string name="dbs_ip_setting">DNS</string>
     <string name="byedpi_version">ByeDPI</string>
-    <string name="bye_dpi_proxy_ip_setting">Dinleme IPsi</string>
+    <string name="bye_dpi_proxy_ip_setting">Dinleme IP\'si</string>
     <string name="byedpi_proxy_port_setting">Port</string>
     <string name="byedpi_max_connections_setting">Maksimum bağlantılar</string>
     <string name="byedpi_buffer_size_setting">Tampon boyutu</string>
@@ -41,7 +41,7 @@
     <string name="byedpi_no_domain_setting">Alan adı yok</string>
     <string name="byedpi_desync_method_setting">Desenkronizasyon yöntemi</string>
     <string name="byedpi_split_position_setting">Bölme pozisyonu</string>
-    <string name="byedpi_split_at_host_setting">Hostta bölme</string>
+    <string name="byedpi_split_at_host_setting">Host\'ta bölme</string>
     <string name="byedpi_fake_ttl_setting">Sahte paketlerin TTL değeri</string>
     <string name="byedpi_host_mixed_case_setting">Karışık harfli host</string>
     <string name="byedpi_domain_mixed_case_setting">Karışık harfli domain</string>
@@ -73,13 +73,13 @@
     <string name="byedpi_desync">Desenkronizasyon</string>
     <string name="command_line_arguments">Komut satırı argümanları</string>
     <string name="byedpi_hosts_mode_setting">Hostlar</string>
-    <string name="byedpi_hosts_blacklist_setting">Host karaliste</string>
+    <string name="byedpi_hosts_blacklist_setting">Host kara liste</string>
     <string name="byedpi_hosts_whitelist_setting">Host beyazliste</string>
     <string name="byedpi_tcp_fast_open_setting">TCP Fast Open</string>
     <string name="byedpi_udp_fake_count">Sahte UDP sayısı</string>
     <string name="ipv6_setting">IPv6</string>
     <string name="byedpi_fake_offset_setting">Sahte paket ofseti</string>
-    <string name="byedpi_drop_sack_setting">SACKı düşür</string>
+    <string name="byedpi_drop_sack_setting">SACK\'ı düşür</string>
     <string name="desync_udp_category">UDP</string>
     <string name="desync_http_category">HTTP</string>
     <string name="desync_https_category">HTTPS</string>
@@ -156,7 +156,7 @@
     <string name="battery_optimization_summary">Kararlılığı artırmak için etkinleştirin</string>
     <string name="battery_optimization_disabled_summary">Devre dışı bırakıldı</string>
     <string name="permission_category">İzinler</string>
-    <string name="documentation_link">Talimat</string>
+    <string name="documentation_link">Talimatlar</string>
     <string name="proxytest_delay_desc">Daha yüksek bir sayı stabiliteyi artırabilir</string>
     <string name="proxytest_requests_desc">Daha yüksek bir sayı doğruluğu artırır ama stabiliteyi azaltabilir</string>
     <string name="proxytest_limit_desc">Daha yüksek bir sayı testi hızlandırır ama stabiliteyi azaltabilir</string>
@@ -165,8 +165,8 @@
     <string name="domain_lists_summary">Test için alan adı listelerini ekleyin, düzenleyin veya kaldırın</string>
     <string name="domain_list_add_new">Yeni Liste Ekle</string>
     <string name="domain_list_add_new_summary">Test edilecek özel alan adları listesi oluşturun</string>
-    <string name="domain_list_edit">Düzeltme</string>
-    <string name="domain_list_delete">Kaldırmak</string>
+    <string name="domain_list_edit">Düzenle</string>
+    <string name="domain_list_delete">Kaldır</string>
     <string name="domain_list_name_hint">Liste adı</string>
     <string name="domain_list_domains_hint">Alan adları (her satırda bir tane)</string>
     <string name="domain_list_summary">%d alan adı</string>
@@ -185,5 +185,6 @@
     <string name="donate">Bağış yapın</string>
     <string name="donate_message">Uygulama işinize yaradıysa, bana bir fincan kahve ısmarlayabilirsiniz ☕️\nDestek ve katılımınız için teşekkürler ❤️</string>
     <string name="donate_cloudtips">CloudTips (yalnızca Rusya kartları)</string>
-    <string name="donate_telegram_bot">Telegram Bot (kartları, cüzdanlar, kripto)</string>
+    <string name="donate_telegram_bot">Telegram Bot (kartlar, cüzdanlar, kripto)</string>
+    <string name="builtin_list_turkey_blocked">Türkiye Yasaklı Domainler</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -187,5 +187,4 @@
     <string name="donate_message">Nếu ứng dụng hữu ích với bạn, bạn có thể mời tôi một tách cà phê ☕️\nCảm ơn sự ủng hộ và đóng góp của bạn ❤️</string>
     <string name="donate_cloudtips">CloudTips (chỉ thẻ Nga)</string>
     <string name="donate_telegram_bot">Telegram Bot (ví điện tử, crypto)</string>
-    <string name="builtin_list_turkey_blocked">Các tên miền bị cấm ở Thổ Nhĩ Kỳ</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -187,4 +187,5 @@
     <string name="donate_message">Nếu ứng dụng hữu ích với bạn, bạn có thể mời tôi một tách cà phê ☕️\nCảm ơn sự ủng hộ và đóng góp của bạn ❤️</string>
     <string name="donate_cloudtips">CloudTips (chỉ thẻ Nga)</string>
     <string name="donate_telegram_bot">Telegram Bot (ví điện tử, crypto)</string>
+    <string name="builtin_list_turkey_blocked">Các tên miền bị cấm ở Thổ Nhĩ Kỳ</string>
 </resources>


### PR DESCRIPTION
Localized Proxy Test Defaults:

* Updated default active domain lists to "türkiye" and "discord" when the app language is set to Turkish.
* Reason: Unlike some other regions, youtube and googlevideo are currently not blocked in Turkey, making the previous defaults less relevant for Turkish users.

Domain List Updates: 
* Added a dedicated list for sites commonly blocked in Turkey. (may need to be updated in the future)

UI and UX Fixes:

* ProxyTestSettingsFragment: Fixed a bug where domain_lists_summary failed to update after modifying domain lists. Added updatePreferences() to onResume to ensure real-time UI synchronization.
* Language Detection: Implemented a more robust getCurrentLanguage method in DomainListUtils that prioritizes AppCompatDelegate locales over system defaults.

Localization and Translations:

* Comprehensive review and correction of Turkish translations for better clarity.
* Updated the Kazakh language array: changed "Түрік" to "Türkçe" to follow proper nomenclature.
* Updated the Turkish README with clearer instructions on using the Proxy Test feature and selecting appropriate domain lists for optimal results.