### PR TITLE
chore(android): migrate foreground service types

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.QUICKBOOT_POWERON" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
@@ -74,7 +76,7 @@
 
         <service android:name=".services.ByeDpiVpnService"
             android:permission="android.permission.BIND_VPN_SERVICE"
-            android:foregroundServiceType="specialUse"
+            android:foregroundServiceType="systemExempted"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.net.VpnService"/>
@@ -83,16 +85,13 @@
                 android:name="android.net.VpnService.SUPPORTS_ALWAYS_ON"
                 android:value="true" />
             <property
-                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:name="android.app.PROPERTY_SYSTEM_EXEMPTED_FGS_SUBTYPE"
                 android:value="vpn" />
         </service>
 
         <service android:name=".services.ByeDpiProxyService"
-            android:foregroundServiceType="specialUse"
+            android:foregroundServiceType="dataSync"
             android:exported="false">
-            <property
-                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
-                android:value="proxy" />
         </service>
 
         <service

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -12,3 +12,4 @@ target_compile_options(byedpi PRIVATE -std=c99 -O2 -Wall -Wno-unused -Wextra -Wn
 target_compile_definitions(byedpi PRIVATE ANDROID_APP)
 
 target_link_libraries(byedpi PRIVATE android log)
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,max-page-size=16384")

--- a/app/src/main/java/io/github/romanvht/byedpi/services/ByeDpiProxyService.kt
+++ b/app/src/main/java/io/github/romanvht/byedpi/services/ByeDpiProxyService.kt
@@ -117,7 +117,7 @@ class ByeDpiProxyService : LifecycleService() {
             startForeground(
                 FOREGROUND_SERVICE_ID,
                 notification,
-                FOREGROUND_SERVICE_TYPE_SPECIAL_USE,
+                android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
             )
         } else {
             startForeground(FOREGROUND_SERVICE_ID, notification)

--- a/app/src/main/java/io/github/romanvht/byedpi/services/ByeDpiVpnService.kt
+++ b/app/src/main/java/io/github/romanvht/byedpi/services/ByeDpiVpnService.kt
@@ -151,7 +151,7 @@ class ByeDpiVpnService : LifecycleVpnService() {
             startForeground(
                 FOREGROUND_SERVICE_ID,
                 notification,
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_SYSTEM_EXEMPTED,
             )
         } else {
             startForeground(FOREGROUND_SERVICE_ID, notification)

--- a/app/src/main/jni/Application.mk
+++ b/app/src/main/jni/Application.mk
@@ -19,3 +19,4 @@ APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_CFLAGS := -O3 -DPKGNAME=io/github/romanvht/byedpi/core
 APP_CPPFLAGS := -O3 -std=c++11
 NDK_TOOLCHAIN_VERSION := clang
+APP_LDFLAGS := -Wl,-z,max-page-size=16384


### PR DESCRIPTION
Update service types to systemExempted and dataSync to fix the FGS crash on new Android 14+. Also apply 16KB page size alignment for native binaries.